### PR TITLE
fix: shoulda-matchers 3.0 requires ruby 2.0

### DIFF
--- a/apress-images.gemspec
+++ b/apress-images.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '>= 2.14.0'
   spec.add_development_dependency 'appraisal', '>= 1.0.2'
   spec.add_development_dependency 'combustion', '>= 0.5.3'
-  spec.add_development_dependency 'shoulda-matchers', '>= 2.8.0'
+  spec.add_development_dependency 'shoulda-matchers', '>= 2.8.0', '< 3.0.0'
   spec.add_development_dependency 'pry-debugger'
   spec.add_development_dependency 'rspec-html-matchers'
 end


### PR DESCRIPTION
Это починит запуск тестов
