### PR TITLE
[WIP] feat: поддержка thoughtbot/paperclip для rails 3.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,16 +1,21 @@
 appraise 'rails3.1' do
   gem 'rails', '~> 3.1.0'
   gem 'strong_parameters'
-  gem 'apress-paperclip', '>= 2.4.3.2'
 end
 
 appraise 'rails3.2' do
   gem 'rails', '~> 3.2.0'
   gem 'strong_parameters'
-  gem 'apress-paperclip', '>= 2.4.3.2'
 end
 
 appraise 'rails4.0' do
   gem 'rails', '~> 4.0.0'
-  gem 'paperclip', '~> 4.3.0'
+end
+
+appraise 'rails4.1' do
+  gem 'rails', '~> 4.1.0'
+end
+
+appraise 'rails4.2' do
+  gem 'rails', '~> 4.2.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ gem 'rails-assets-FileAPI', source: 'https://rails-assets.org/'
 group :test do
   gem 'factory_girl_rails', require: false
 end
+
+group :development, :test do
+  gem 'pry-debugger', require: false
+end

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 RAILS_ENV = test
-BUNDLE = RAILS_ENV=${RAILS_ENV} bundle
-BUNDLE_OPTIONS = --jobs=2
+BUNDLE_VERSION = 1.7.15
+BUNDLE = RAILS_ENV=${RAILS_ENV} bundle _${BUNDLE_VERSION}_
+BUNDLE_OPTIONS = --jobs=3 --quiet
 RSPEC = rspec
 APPRAISAL = appraisal
 
@@ -23,9 +24,7 @@ configs:
 	echo "$${DATABASE_YML}" > spec/internal/config/database.yml
 
 bundler:
-	if ! gem list bundler -i > /dev/null; then \
-	  gem install bundler; \
-	fi
+	gem list bundler | grep '^bundler\s.*' > /dev/null || gem install bundler --no-ri --no-rdoc --version=${BUNDLE_VERSION}
 	${BUNDLE} install ${BUNDLE_OPTIONS}
 
 appraisal:

--- a/README.md
+++ b/README.md
@@ -1,27 +1,20 @@
 # Apress::Images
 
-[![Dolly](http://dolly.railsc.ru/badges/abak-press/apress-images/master)](http://dolly.railsc.ru/projects/83/builds/latest/?ref=master)
+<a href="http://dolly.railsc.ru/projects/83/builds/latest/?ref=paperclip-upgrade"><img src="http://dolly.railsc.ru/badges/abak-press/apress-images/paperclip-upgrade" height="18"></a>
 
 Предоставляет функционал для загрузки и прикрепления изображений
 
+## Requirements
+
+paperclip >= v4.x.x
+
 ## Installation
 
-### Rails 3.x
-
 Add this lines to your application's Gemfile:
 
 ```ruby
-gem 'apress-paperclip'
-gem 'apress-images'
-```
-
-### Rails 4.x
-
-Add this lines to your application's Gemfile:
-
-```ruby
-gem 'paperclip', '~> 4.3.0'
-gem 'apress-images', '> 2.0'
+gem 'paperclip', '~> 4.2'
+gem 'apress-images', git: 'git@github.com:abak-press/apress-images.git', branch: 'paperclip-upgrade'
 ```
 
 And then execute:
@@ -41,16 +34,50 @@ Or install it yourself as:
 
 class Avatar < ActiveRecord::Base
   include Apress::Images::Imageable
-  
-  acts_as_image({
+
+  acts_as_image(
     attachment_options: {
       styles: {thumb: '100x100>'}
     },
-    background_processing: false, # допустим, ресайз не хотим делать в фоне,
-    max_size: 4, # Максимальный размер изображения ставим в 4 Мб
-    watermark_small: 'my_watermark.png' # Своя ватермарка
-  })
+    max_size: 4, # Максимальный размер изображения ставим в 4 Мб (по-умолчанию 15 Мб)
+    watermark_small: 'my_watermark.png', # Своя ватермарка
+    background_processing: true # допустим, хотим, чтобы ресайз происходил в фоне
+  )
 end
+
+```
+
+### Указываем таблицу (по-умолчанию 'images')
+
+```ruby
+
+class Dummy < ActiveRecord::Base
+  acts_as_image(table_name: 'dummies')
+end
+```
+
+### Фоновая обработка изображений
+
+```ruby
+
+class Avatar < ActiveRecord::Base
+  include Apress::Images::Imageable
+
+  acts_as_image(
+    background_processing: true,
+    processing_image_url: '/images/:style/processing.jpg' # выставить свою заглушку изображения на время ресайза
+  )
+end
+
+@avatar = Avatar.new(img: File.new(...))
+@avatar.save
+@avatar.img.url # => /images/original/processing.png
+@avatar.img.url(:thumb) # => /images/thumb/processing.png
+
+# После ресайза в фоне
+
+@avatar.reload
+@avatar.img.url #=> "/system/images/3/original/IMG_2772.JPG?1267562148"
 
 ```
 

--- a/app/jobs/apress/images/process_job.rb
+++ b/app/jobs/apress/images/process_job.rb
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-require 'resque-integration'
-
 module Apress
   module Images
     class ProcessJob
@@ -9,12 +7,13 @@ module Apress
 
       queue :images
 
-      unique { |image_id, _| [image_id] }
+      unique
 
       def self.execute(image_id, class_name)
         model = class_name.camelize.constantize
         image = model.find_by_id(image_id)
-        image.regenerate_styles! if image.present? && image.processing?
+
+        image.img.process_delayed! if image.present? && image.processing?
       end
     end
   end

--- a/app/models/apress/images/extensions/background_processing.rb
+++ b/app/models/apress/images/extensions/background_processing.rb
@@ -3,92 +3,48 @@
 module Apress
   module Images
     module Extensions
-      # Internal: Предоставляет возможность обработки изображения в фоне
+      # Public: отложенная обработка изображений
       module BackgroundProcessing
         extend ActiveSupport::Concern
 
-        included do
-          attr_writer :post_process
+        module ClassMethods
+          # Public: конфигурирует модель изображения для обработки в фоне
+          #
+          # options - Hash,
+          #   :processing_image_url - String, путь к картинке-заглушке
+          #   :queue_name - Symbol, очередь обработки, по-умолчанию :images
+          #
+          # Returns nothing
+          def process_in_background(options = {})
+            attachment_definitions[:img][:delayed] = options.reverse_merge!(
+              processing_image_url: nil,
+              queue_name: :images # TODO: добавить возможность выставить в кастомную очередь
+            )
 
-          class << self
-            attr_writer :post_process
+            after_commit :enqueue_delayed_processing
           end
-
-          before_img_post_process :prepare_image_to_process
-
-          before_save :store_img_status_changing, if: :img_changed?
-          after_commit :set_stubs, :enqueue_resizing, if: proc { post_process? && @_img_changed }
         end
 
-        def regenerate_styles!
-          img.reprocess!
-          self.processing = false
-          save(validate: false)
-        end
-
-        def post_process
-          @post_process.nil? ? self.class.post_process : @post_process
-        end
-
-        def post_process?
-          !!post_process
+        # Public: пометить для последующей обработки
+        # вызывается перед сохранением attachment'а
+        #
+        # Returns nothing
+        def prepare_enqueuing
+          self.processing = true
+          nil
         end
 
         protected
 
-        def store_img_status_changing
-          @_img_changed = true
-        end
-
-        # Internal: Поставить в очередь на ресайзинг
+        # Internal: выставить в очередь на обработку
         #
         # Returns nothing
-        def enqueue_resizing
+        def enqueue_delayed_processing
+          return if !img_changed? || reload.processing?
+
+          self.class.where(id: id).update_all(processing: true)
+
           Apress::Images::ProcessJob.enqueue(id, self.class.name)
-          nil
-        end
-
-        # Internal: Прерывает ресайз картинки, если она изменилась
-        # чтобы ресайзинг происходил в фоне
-        #
-        # Returns Boolean
-        def prepare_image_to_process
-          return if !post_process? || !img_changed?
-
-          self.processing = true
-          false # halts processing
-        end
-
-        # Intenal: Выставить заглушки
-        def set_stubs
-          return self unless img.file?
-
-          thumbs.each do |name|
-            tmp_file = ::Tempfile.new([name, '.gif'])
-            ::FileUtils.cp stub_path(name), tmp_file.path
-            img.queued_for_write[name] = tmp_file
-          end
-
-          img.flush_writes
-        end
-
-        def stub_path(style)
-          return super if defined?(super)
-
-          File.join(Rails.public_path, %W(images stub_#{style}.gif))
-        end
-
-        module ClassMethods
-          # Public:class post process option, default true
-          #
-          # Returns boolean
-          def post_process
-            @post_process.nil? ? true : @post_process
-          end
-
-          def post_process?
-            !!post_process
-          end
         end
       end
     end

--- a/app/models/concerns/apress/images/imageable.rb
+++ b/app/models/concerns/apress/images/imageable.rb
@@ -5,9 +5,10 @@ module Apress
     # Public: Добавляет к сущностям возможность прикреплять картинки
     module Imageable
       extend ActiveSupport::Concern
-
+      # Public: таблица, где хранятся картинки, по-умолчанию
+      TABLE_NAME = 'images'.freeze
       # Public: максимальный размер вложения, Мб
-      MAX_SIZE = 2
+      MAX_SIZE = 15
       # Public: допустимые форматы
       ALLOWED_MIME_TYPES = /\Aimage\/(jpeg|png|gif|pjpeg)\Z/.freeze
       # Public: шаблоны допустимых названий файлов
@@ -16,6 +17,27 @@ module Apress
       WATERMARK_SMALL = File.join(Rails.public_path, 'images', 'pcwm-small.png').freeze
       # Public: путь к большому водяному знаку по-умолчанию
       WATERMARK_BIG = File.join(Rails.public_path, 'images', 'pcwm-big.png').freeze
+      # Public: опции по-умолчанию
+      DEFAULT_OPTIONS = {
+        default_style: :thumb,
+        processors: [:watermark],
+        convert_options: {
+          original: '-strip -interlace Plane -quality 85',
+          thumb: '-strip -quality 85'
+        },
+        styles: {
+          original: {
+            geometry: '1280x1024>',
+            animated: false
+          },
+          thumb: {
+            geometry: '90x90>',
+            animated: false,
+            watermark_path: WATERMARK_SMALL
+          }
+        },
+        url: '/system/images/:class/:id_partition_:style.:extension'
+      }.freeze
 
       module ClassMethods
         # Public: Добавляет поведение картинки в модель active_record
@@ -23,6 +45,8 @@ module Apress
         # Returns nothing
         def acts_as_image(options = {})
           options.symbolize_keys!
+
+          self.table_name = TABLE_NAME unless options[:table_name]
 
           define_singleton_method :attachment_options do
             default_attachment_options.deep_merge(options.fetch(:attachment_options, {}))
@@ -34,34 +58,20 @@ module Apress
           define_singleton_method(:watermark_big) { options.fetch :watermark_big, WATERMARK_BIG }
           define_singleton_method(:allowed_file_names) { options.fetch :allowed_file_names, ALLOWED_FILE_NAMES }
 
-          include Apress::Images::Extensions::Imageable
-          include(Apress::Images::Extensions::BackgroundProcessing) if options.fetch(:background_processing, true)
+          include Apress::Images::Extensions::Image
+
+          return unless options.fetch(:background_processing, true)
+
+          include(Apress::Images::Extensions::BackgroundProcessing)
+
+          process_in_background options.slice(:processing_image_url, :queue_name)
         end
 
         # Public: Опции по-умолчанию
         #
         # Returns Hash
         def default_attachment_options
-          {
-            use_file_command: true,
-            default_style: :thumb,
-            processors: [:watermark],
-            convert_options: {
-              all: '-strip -quality 90'
-            },
-            styles: {
-              original: {
-                geometry: '1280x1024>',
-                animated: false
-              },
-              thumb: {
-                geometry: '90x90>',
-                animated: false,
-                watermark_path: watermark_small
-              }
-            },
-            url: '/system/images/:class/:id_partition_:style.:extension'
-          }
+          DEFAULT_OPTIONS
         end
       end
     end

--- a/apress-images.gemspec
+++ b/apress-images.gemspec
@@ -19,12 +19,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w(lib)
 
-  spec.add_runtime_dependency 'rails', '>= 3.1.12', '< 4.1'
+  spec.add_runtime_dependency 'rails', '>= 3.1.12', '< 5'
   spec.add_runtime_dependency 'pg'
+  spec.add_runtime_dependency 'paperclip', '~> 4.2'
+  spec.add_runtime_dependency 'russian', '>= 0.6'
   spec.add_runtime_dependency 'resque-integration', '>= 0.4.1'
   spec.add_runtime_dependency 'addressable', '>= 2.3.2'
-  spec.add_runtime_dependency 'haml'
-  spec.add_runtime_dependency 'rails-assets-FileAPI'
+  spec.add_runtime_dependency 'haml', '>= 4.0.7'
+  spec.add_runtime_dependency 'rails-assets-FileAPI', '>= 2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake'
@@ -32,7 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '>= 2.14.0'
   spec.add_development_dependency 'appraisal', '>= 1.0.2'
   spec.add_development_dependency 'combustion', '>= 0.5.3'
-  spec.add_development_dependency 'shoulda-matchers', '>= 2.8.0', '< 3.0.0'
-  spec.add_development_dependency 'pry-debugger'
-  spec.add_development_dependency 'rspec-html-matchers'
+  spec.add_development_dependency 'shoulda-matchers', '< 3'
+  spec.add_development_dependency 'rspec-html-matchers', '>= 0.7'
+  spec.add_development_dependency 'simplecov', '>= 0.9'
+  spec.add_development_dependency 'test_after_commit', '>= 0.2.3'
+  spec.add_development_dependency 'mock_redis', '>= 0.15.3'
 end

--- a/lib/apress/images.rb
+++ b/lib/apress/images.rb
@@ -2,6 +2,9 @@
 
 require 'rails'
 require('strong_parameters') if Rails::VERSION::MAJOR < 4
+require 'addressable/uri'
+require 'resque/integration'
+require 'russian'
 require 'paperclip'
 require 'paperclip/watermark'
 require 'action_view'
@@ -12,11 +15,5 @@ require 'apress/images/version'
 
 module Apress
   module Images
-    # Public: определяет, является ли установленная версия paperclip старше v4.0
-    #
-    # Returns boolean
-    def self.old_paperclip?
-      Gem::Version.new(Paperclip::VERSION) < Gem::Version.new('4.0.0')
-    end
   end
 end

--- a/lib/apress/images/engine.rb
+++ b/lib/apress/images/engine.rb
@@ -5,11 +5,19 @@ module Apress
     class Engine < ::Rails::Engine
       config.autoload_paths += Dir["#{config.root}/lib"]
       config.autoload_paths += [config.root.join('app', 'models', 'concerns')] if Rails::VERSION::MAJOR < 4
-      config.i18n.load_path += Dir[config.root.join('locales', '*.{rb,yml}').to_s]
+      config.i18n.load_path += Dir[config.root.join('config', 'locales', '*.{rb,yml}').to_s]
 
       initializer 'apress-images', before: :load_config_initializers do
         config.imageable_models = Set.new(['Apress::Images::Image'])
         config.imageable_subjects = Set.new
+
+        Paperclip::Attachment.send(:include, Apress::Images::Extensions::Attachment)
+
+        Paperclip::Attachment.default_options[:url_generator] = Apress::Images::UrlGenerator
+
+        Paperclip.io_adapters.register Paperclip::UriAdapter do |target|
+          target.is_a?(Addressable::URI)
+        end
       end
 
       initializer :define_apress_images_migration_paths do |app|

--- a/lib/apress/images/extensions/attachment.rb
+++ b/lib/apress/images/extensions/attachment.rb
@@ -1,0 +1,168 @@
+# coding: utf-8
+
+module Apress
+  module Images
+    module Extensions
+      module Attachment
+        extend ActiveSupport::Concern
+
+        included do
+          # Public: флаг, сигнализирующий о происходящей обработке
+          attr_accessor :job_is_processing
+          attr_writer :post_processing_with_delay
+
+          alias_method_chain :post_processing, :delay
+          alias_method_chain :post_processing=, :delay
+
+          alias_method_chain :save, :prepare_enqueuing
+        end
+
+        # Public: находится ли attachment в обработке?
+        #
+        # Returns
+        def processing?
+          return unless instance.respond_to?(:processing?)
+          instance.processing?
+        end
+
+        # Public: опции отложенной обработки
+        # Возвращает из attachment_definitions[name][:delayed], выставленном при вызове
+        # process_in_background на модели
+        #
+        # Returns Hash, nil если для модели не предусмотрена отложенная обработка
+        def delayed_options
+          options[:delayed]
+        end
+
+        # Public: запустить отложенную обработку
+        #
+        # Returns nothing
+        def process_delayed!
+          self.job_is_processing = true
+          self.post_processing = true
+
+          if exists?(:original)
+            reprocess!
+          else
+            log("Original not exists for image #{instance.id}")
+
+            begin
+              file = to_file(most_existing_style)
+
+              assign(file)
+
+              reprocess!
+            rescue
+              log("Could not restore original for image #{instance.id}")
+            ensure
+              file.close if file
+            end
+          end
+
+          self.job_is_processing = false
+
+          update_processing_column
+        end
+
+        # Public: пометить модель для отложенной обработки
+        #
+        # Returns nothing
+        def save_with_prepare_enqueuing
+          was_dirty = @dirty
+
+          save_without_prepare_enqueuing.tap do
+            instance.prepare_enqueuing if delay_processing? && was_dirty
+          end
+        end
+
+        # Public: запустить обработку вне фона
+        #
+        # Returns nothing
+        def reprocess_without_delay!(*style_args)
+          @post_processing_with_delay = true
+          reprocess!(*style_args)
+        end
+
+        # Public: установлен ли флаг для отложенной обработки attаchment'а
+        #
+        # Returns Boolean
+        def delay_processing?
+          if @post_processing_with_delay.nil?
+            !!delayed_options
+          else
+            !@post_processing_with_delay
+          end
+        end
+
+        # Public: путь к картинке-заглушке
+        #
+        # Returns String
+        def processing_image_url
+          return unless delayed_options
+          img_stub_path = delayed_options[:processing_image_url]
+          img_stub_path = img_stub_path.call(self) if img_stub_path.respond_to?(:call)
+          img_stub_path
+        end
+
+        def post_processing_with_delay
+          !delay_processing?
+        end
+
+        # Public: стили кроме оригинала
+        #
+        # Returns Array
+        def thumbs
+          styles.keys.reject { |style| style == :original }
+        end
+
+        # Public: пути в файловой системе для каждого стиля
+        #
+        # Returns Hash
+        def files
+          styles.keys.each_with_object({}) do |style, result|
+            result[style] = path(style)
+            result
+          end
+        end
+
+        # Public: список хешей для каждого стиля
+        #
+        # Returns Hash
+        def fingerprints
+          files.each_with_object({}) do |(style, file), result|
+            result[style] = Digest::MD5.file(file).to_s
+            result
+          end
+        end
+
+        # Public: из всех стилей первый, файл которого существует
+        #
+        # Returns Symbol
+        def most_existing_style
+          thumbs.find { |t| exists?(t) }
+        end
+
+        # Public: файл для стиля
+        #
+        # Returns Tempfile
+        def to_file(style)
+          tmpfile = Tempfile.new(path(style))
+          copy_to_local_file(most_existing_style, tmpfile.path)
+          tmpfile.rewind
+          tmpfile
+        end
+
+        private
+
+        # Internal: сбросить флаг фоновой обработки и записать в базу
+        #
+        # Returns nothing
+        def update_processing_column
+          return unless instance.processing?
+          instance.processing = false
+          instance.class.where(instance.class.primary_key => instance.id).update_all(processing: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/apress/images/url_generator.rb
+++ b/lib/apress/images/url_generator.rb
@@ -1,0 +1,45 @@
+# coding: utf-8
+require 'paperclip/url_generator'
+
+module Apress
+  module Images
+    # Public: расширенный класс генератора url для обрабатываемых в фоне картинок
+    class UrlGenerator < ::Paperclip::UrlGenerator
+      attr_reader :attachment, :attachment_options
+
+      def for(style_name, options)
+        interpolated_url = attachment_options[:interpolator].interpolate(most_appropriate_url, attachment, style_name)
+        escaped_url = escape_url_as_needed(interpolated_url, options)
+
+        timestamp_as_needed(escaped_url, options)
+      end
+
+      # Public: наиболее подходящий url к картинке
+      #
+      # если картинка в обработке и предоставлен путь к заглушке, вернет Url до заглушки
+      # иначе вернет url по-умолчанию
+      #
+      # Returns String
+      def most_appropriate_url
+        return super unless attachment.processing?
+        return attachment_options[:url] if attachment.original_filename.present? && !delayed_default_url?
+
+        if attachment.delayed_options && attachment.processing_image_url && attachment.processing?
+          return attachment.processing_image_url
+        end
+
+        default_url
+      end
+
+      def timestamp_possible?
+        delayed_default_url? ? false : super
+      end
+
+      def delayed_default_url?
+        !attachment.job_is_processing && !attachment.dirty? &&
+          attachment.delayed_options.try(:[], :processing_image_url) &&
+          attachment.processing?
+      end
+    end
+  end
+end

--- a/lib/paperclip/watermark.rb
+++ b/lib/paperclip/watermark.rb
@@ -37,14 +37,7 @@ module Paperclip
           :watermark => watermark_path
         )
       rescue Cocaine::ExitStatusError
-        if @whiny
-          error = "There was an error processing the watermark for #{@basename}"
-          if Apress::Images.old_paperclip?
-            raise PaperclipError, error
-          else
-            raise Paperclip::Error, error
-          end
-        end
+        raise Paperclip::Error, "There was an error processing the watermark for #{@basename}" if @whiny
       rescue Cocaine::CommandNotFoundError
         raise Paperclip::CommandNotFoundError.new("Could not run the `#{program}` command. Please install ImageMagick.")
       end

--- a/spec/app/controllers/apress/images/images_controller_spec.rb
+++ b/spec/app/controllers/apress/images/images_controller_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 RSpec.describe Apress::Images::ImagesController, type: :controller do
   before do
     Rails.application.config.imageable_models << 'SubjectImage'
-    SubjectImage.post_process = false
   end
 
   let(:image_in_process) { create :subject_image, processing: true }

--- a/spec/app/jobs/apress/images/process_job_spec.rb
+++ b/spec/app/jobs/apress/images/process_job_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Apress::Images::ProcessJob do
   describe '.execute' do
     let(:image) { create :subject_image, processing: true }
 
-    it { expect_any_instance_of(SubjectImage).to receive(:regenerate_styles!) }
+    before { allow_any_instance_of(Paperclip::Attachment).to receive(:process_delayed!) }
+
+    it { expect_any_instance_of(Paperclip::Attachment).to receive(:process_delayed!) }
 
     after { described_class.execute(image.id, image.class.name) }
   end

--- a/spec/app/models/apress/images/extensions/background_processing_spec.rb
+++ b/spec/app/models/apress/images/extensions/background_processing_spec.rb
@@ -1,0 +1,31 @@
+# coding: utf-8
+require 'spec_helper'
+
+RSpec.describe Apress::Images::Extensions::BackgroundProcessing do
+  describe '.process_in_background' do
+    it do
+      expect(DelayedImage.attachment_definitions[:img][:delayed]).to have_key(:processing_image_url)
+      expect(DelayedImage.attachment_definitions[:img][:delayed]).to have_key(:queue_name)
+    end
+  end
+
+  describe '#enqueue_delayed_processing' do
+    let(:image) { build :delayed_image }
+
+    before { allow(Apress::Images::ProcessJob).to receive(:enqueue) }
+
+    context 'when update processing field' do
+      before { image.save }
+
+      it { expect(image.reload).to be_processing }
+    end
+
+    context 'when enqueing' do
+      it do
+        expect(Apress::Images::ProcessJob).to receive(:enqueue).with(instance_of(Fixnum), image.class.name)
+      end
+
+      after { image.save }
+    end
+  end
+end

--- a/spec/app/models/apress/images/subject_image_spec.rb
+++ b/spec/app/models/apress/images/subject_image_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe SubjectImage, type: :model do
   let(:image) { build :subject_image }
+  let(:dummy_filepath) { Rails.root.join('../fixtures/images/sample_image.jpg') }
 
   before { allow(Apress::Images::ProcessJob).to receive(:enqueue) }
 
@@ -17,8 +18,15 @@ RSpec.describe SubjectImage, type: :model do
     it { expect(image.styles).to eq described_class.attachment_options[:styles].keys }
   end
 
-  describe '#thumbs' do
-    it { expect(image.thumbs).to eq described_class.attachment_options[:styles].keys.reject { |s| s == :original } }
+  describe 'delegated methods' do
+    before { allow_any_instance_of(Paperclip::Attachment).to receive(:path).and_return(dummy_filepath) }
+
+    it 'delegates attachment methods' do
+      expect(image.thumbs).to eq(image.img.thumbs)
+      expect(image.files).to eq(image.img.files)
+      expect(image.fingerprints).to eq(image.img.fingerprints)
+      expect(image.most_existing_style).to eq(image.img.most_existing_style)
+    end
   end
 
   describe '#normalize_positions' do
@@ -35,11 +43,5 @@ RSpec.describe SubjectImage, type: :model do
 
       after { image.destroy }
     end
-  end
-
-  describe '#store_img_status_changing' do
-    let(:image) { create :subject_image }
-
-    it { expect(image.instance_variable_get(:@_img_changed)).to eq true }
   end
 end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -12,4 +12,9 @@ FactoryGirl.define do
     img { Rack::Test::UploadedFile.new(Rails.root.join('../fixtures/images/sample_image.jpg'), 'image/jpeg') }
     position 1
   end
+
+  factory :delayed_image, class: DelayedImage do
+    img { Rack::Test::UploadedFile.new(Rails.root.join('../fixtures/images/sample_image.jpg'), 'image/jpeg') }
+    position 1
+  end
 end

--- a/spec/internal/app/models/delayed_image.rb
+++ b/spec/internal/app/models/delayed_image.rb
@@ -1,0 +1,9 @@
+class DelayedImage < ActiveRecord::Base
+  include Apress::Images::Imageable
+
+  acts_as_image(
+    background_processing: true,
+    processing_image_url: 'foo.jpg',
+    queue_name: :base
+  )
+end

--- a/spec/internal/app/models/subject_image.rb
+++ b/spec/internal/app/models/subject_image.rb
@@ -1,1 +1,5 @@
-SubjectImage = Class.new(Apress::Images::Image)
+class SubjectImage < ActiveRecord::Base
+  include Apress::Images::Imageable
+
+  acts_as_image(background_processing: false)
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -1,3 +1,11 @@
 ActiveRecord::Schema.define do
   create_table(:subjects, force: true)
+
+  create_table :delayed_images, force: true do |t|
+    t.string :img_file_name
+    t.string :img_content_type
+    t.integer :img_file_size
+    t.integer :position, null: false, default: 0
+    t.boolean :processing, null: false, default: false
+  end
 end

--- a/spec/lib/apress/images/extensions/attachment_spec.rb
+++ b/spec/lib/apress/images/extensions/attachment_spec.rb
@@ -1,0 +1,148 @@
+# coding: utf-8
+
+require 'spec_helper'
+
+RSpec.describe Paperclip::Attachment do
+  let(:image) { build_stubbed :delayed_image }
+  let(:dummy_filepath) { Rails.root.join('../fixtures/images/sample_image.jpg') }
+  let(:dummy_fingerprint) { Digest::MD5.file(dummy_filepath).to_s }
+
+  before do
+    # не даем писать на диск
+    allow_any_instance_of(Paperclip::Attachment).to receive_messages(flush_writes: nil, flush_deletes: nil)
+  end
+
+  describe '#processing?' do
+    let(:image) { build :subject_image }
+
+    it { expect(image.img).to respond_to :processing? }
+  end
+
+  describe '#delayed_options' do
+    context 'when process in background setted' do
+      let(:options) { DelayedImage.new.img.delayed_options }
+
+      it do
+        expect(options[:processing_image_url]).to eq('foo.jpg')
+        expect(options[:queue_name]).to eq(:base)
+      end
+    end
+
+    context 'when not setted' do
+      it { expect(SubjectImage.new.img.delayed_options).to be_nil }
+    end
+  end
+
+  describe '#save_with_prepare_enqueuing' do
+    it { expect { image.img.send(:save) }.to change(image, :processing?).from(false).to true }
+  end
+
+  describe '#process_delayed!' do
+    let(:image) { build_stubbed :delayed_image, processing: true }
+
+    before { allow(image).to receive(:save) }
+
+    context 'when processing' do
+      it do
+        expect(image.img).to receive(:job_is_processing=).with(false).once
+        expect(image.img).to receive(:job_is_processing=).with(true).once
+        expect(image.img).to receive(:post_processing=).with(true)
+      end
+
+      after { image.img.process_delayed! }
+    end
+
+    context 'when processed' do
+      before { image.img.process_delayed! }
+
+      it { expect(image.processing).to be_falsy }
+    end
+
+    context 'when original missing' do
+      let(:image) { create :subject_image }
+
+      before do
+        allow_any_instance_of(Paperclip::Attachment).to receive(:update_processing_column)
+        File.unlink(image.img.path(:original))
+      end
+
+      it 'restores original from must existing style' do
+        expect(image.img).not_to be_exists(:original)
+        image.img.process_delayed!
+        expect(image.img).to be_exists(:original)
+      end
+    end
+  end
+
+  describe '#most_existing_style' do
+    before { allow_any_instance_of(described_class).to receive(:path).and_return(dummy_filepath) }
+
+    it { expect(image.img.most_existing_style).to eq(:thumb) }
+  end
+
+  describe '#thumbs' do
+    it { expect(image.img.thumbs).to match_array([:thumb]) }
+  end
+
+  describe '#files' do
+    let(:expected_paths) do
+      {
+        original: image.img.path(:original),
+        thumb: image.img.path(:thumb)
+      }
+    end
+
+    it { expect(image.img.files).to eq expected_paths }
+  end
+
+  describe '#fingerprints' do
+    let(:expected_hash) do
+      {
+        original: dummy_fingerprint,
+        thumb: dummy_fingerprint
+      }
+    end
+
+    before { allow_any_instance_of(described_class).to receive(:path).and_return(dummy_filepath) }
+
+    it { expect(image.img.fingerprints).to eq(expected_hash) }
+  end
+
+  describe '#processing_image_url' do
+    let!(:options_before) { DelayedImage.attachment_definitions[:img][:delayed] }
+
+    context 'when stub url callable' do
+      before do
+        DelayedImage.attachment_definitions[:img][:delayed] = {
+          processing_image_url: ->(img) { "test_#{img.instance.id}.jpg" }
+        }
+      end
+
+      it 'constructs url with image context' do
+        expect(image.img.processing_image_url).to eq("test_#{image.id}.jpg")
+      end
+
+      after { DelayedImage.attachment_definitions[:img][:delayed] = options_before }
+    end
+
+    context 'when background processing disabled' do
+      before { DelayedImage.attachment_definitions[:img][:delayed] = nil }
+
+      it { expect(image.img.processing_image_url).to be_nil }
+
+      after { DelayedImage.attachment_definitions[:img][:delayed] = options_before }
+    end
+
+    context 'when stub url is string' do
+      before do
+        DelayedImage.attachment_definitions[:img][:delayed] = {
+          processing_image_url: '/images/dummy/stub.jpg'
+        }
+      end
+
+      it { expect(image.img.processing_image_url).to eq('/images/dummy/stub.jpg') }
+
+      after { DelayedImage.attachment_definitions[:img][:delayed] = options_before }
+    end
+  end
+end

--- a/spec/lib/apress/images/url_generator_spec.rb
+++ b/spec/lib/apress/images/url_generator_spec.rb
@@ -1,0 +1,25 @@
+# coding: utf-8
+require 'spec_helper'
+
+RSpec.describe Apress::Images::UrlGenerator do
+  describe '#most_appropriate_url' do
+    let!(:options_before) { DelayedImage.attachment_definitions[:img][:delayed] }
+
+    context 'when stub url present' do
+      let(:processing_image) { create :delayed_image, processing: true }
+
+      before do
+        DelayedImage.attachment_definitions[:img][:delayed] = {
+          processing_image_url: 'stub_:style.jpg'
+        }
+      end
+
+      it 'returns interpolated paths to stub image' do
+        expect(processing_image.img.url(:original)).to eq('stub_original.jpg')
+        expect(processing_image.img.url(:thumb)).to eq('stub_thumb.jpg')
+      end
+
+      after { DelayedImage.attachment_definitions[:img][:delayed] = options_before }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,13 @@
 # coding: utf-8
 
 require 'bundler/setup'
-require 'apress/images'
 
-require 'paperclip/matchers'
+require 'simplecov'
+SimpleCov.start 'rails' do
+  minimum_coverage 95
+end
+
+require 'apress/images'
 
 require 'combustion'
 Combustion.initialize! :all do
@@ -14,7 +18,14 @@ end
 require 'rspec/rails'
 require 'factory_girl_rails'
 require 'shoulda-matchers'
+require 'paperclip/matchers'
 require 'rspec-html-matchers'
+require 'test_after_commit'
+
+require 'mock_redis'
+Resque.redis = MockRedis.new
+
+Paperclip.options[:logger] = Rails.logger
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-6698
- Выпиливается поддержка apress-paperclip, основанного на старом paperclip
- Можно задать свое имя таблицы
- Улучшенная фоновая обработка изображения (inspired by [delayed_paperclip](https://github.com/jrgifford/delayed_paperclip), старая логика оказалась не совместима с новым paperclip:
1. Картинки-заглушки больше не пишем каждый раз на диск для каждого инстанса изображения ( [ссылка](https://github.com/abak-press/apress-images/blob/master/app/models/apress/images/extensions/background_processing.rb#L72) и [откуда](https://github.com/abak-press/pulscen/blob/develop/vendor/plugins/core_products/app/models/core_products/extensions/product_image.rb#L473) был взят этот код), а берем и подставляем во время процессинга при вызове метода instance_image.img.url([style]) путь к заглушке. 
2. Стоит отметить, что reprocess! в новом paperclip вызывает save на инстансе модели, [ссылка](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment.rb#L338). Поэтому в старом варианте возникала проблема с выставлением "заглушек"

TODO: 
- [x] Дополнить логикой обработки ситуации при отсутсвии оригинала картинки 
- [x] Проверить совместимость с paperdist и вебдав
- [x] Загрузка с удаленного урла - проверить
- [x] Тесты - довести с 89 до 95 %
