### PR TITLE
fix error when assigning images through nested attributes

### DIFF
--- a/app/models/concerns/apress/images/acts_as_subjectable.rb
+++ b/app/models/concerns/apress/images/acts_as_subjectable.rb
@@ -26,14 +26,8 @@ module Apress
         #
         #      accepts_nested_attributes_for :cover, allow_destroy: true
         #
-        #      def cover_with_build
-        #         cover_without_build || build_cover()
-        #      end
-        #      alias_method_chain :cover, :build
-        #
         #      def cover_attributes=(attributes)
-        #        self.cover = Apress::Deals::OfferCover.find(attributes['id']) \
-        #          if attributes['id'].present? && new_record?
+        #        self.cover = Apress::Deals::OfferCover.find(attributes['id']) if attributes['id'].present?
         #        assign_nested_attributes_for_one_to_one_association(:cover, attributes)
         #      end
         #
@@ -50,23 +44,12 @@ module Apress
           return if type != :has_one
 
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            # Public: Получение уже созданной записи картинки или её инициализация.
-            #
-            # Returns Image.
-            def #{name}_with_build
-              #{name}_without_build || build_#{name}(#{options[:conditions]})
-            end
-            alias_method_chain :#{name}, :build
-          RUBY
-
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
             self.send :include, (Module.new do
               extend ActiveSupport::Concern
 
               included do
                 def #{name}_attributes=(attributes)
-                  self.#{name} = #{options[:class_name]}.find(attributes['id']) \\
-                    if attributes['id'].present? && new_record?
+                  self.#{name} = #{options[:class_name]}.find(attributes['id']) if attributes['id'].present?
                   assign_nested_attributes_for_one_to_one_association(:#{name}, attributes)
                 end
               end

--- a/spec/app/models/apress/images/subject_spec.rb
+++ b/spec/app/models/apress/images/subject_spec.rb
@@ -7,53 +7,34 @@ RSpec.describe Subject, type: :model do
   it { expect(subject).to have_one(:cover).class_name('SubjectImage') }
   it { expect(described_class.reflect_on_association(:cover).options[:as]).to eq(:subject) }
   it { expect(subject).to accept_nested_attributes_for(:cover).allow_destroy(true) }
-  it { expect(subject.cover).to be_kind_of SubjectImage }
 
-  context 'when subject is new record' do
-    context 'when create without cover' do
-      let(:subject) { build :subject }
+  context 'when initializing and saving subject with image assigned through nested attributes' do
+    let(:image) { create :subject_image }
+    let(:subject) { Subject.new(attributes_for(:subject).merge(cover_attributes: {'id' => image.id})) }
 
-      before { subject.save }
+    before { subject.save }
 
-      it { expect(subject.persisted?).to be_truthy }
-      it { expect(subject.cover.persisted?).to be_falsey }
-    end
-
-    context 'when create with cover' do
-      let(:image) { create :subject_image }
-      let(:subject) { described_class.new(attributes_for(:subject).merge(cover_attributes: {'id' => image.id})) }
-
-      before { subject.save }
-
-      it { expect(subject.persisted?).to be_truthy }
-      it { expect(subject.cover.persisted?).to be_truthy }
-      it { expect(subject.cover).to eq image }
+    it do
+      expect(subject).to be_persisted
+      expect(subject.cover).to be_persisted
+      expect(subject.cover).to eq(image)
     end
   end
 
   context 'when subject exists' do
-    context 'when subject has not cover' do
-      context 'when update without cover' do
-        let(:subject) { create :subject }
+    context 'when updating subject with image through nested attributes' do
+      let(:subject) { create :subject }
+      let(:image) { create :subject_image, subject_id: subject.id, subject_type: subject.class.name }
 
-        before { subject.save }
-
-        it { expect(subject.persisted?).to be_truthy }
-        it { expect(subject.cover.persisted?).to be_falsey }
+      before do
+        subject.assign_attributes(cover_attributes: {'id' => image.id})
+        subject.save
       end
 
-      context 'when update with cover' do
-        let(:subject) { create :subject }
-        let(:image) { create :subject_image, subject_id: subject.id, subject_type: subject.class.name }
-
-        before do
-          subject.assign_attributes(cover_attributes: {'id' => image.id})
-          subject.save
-        end
-
-        it { expect(subject.persisted?).to be_truthy }
-        it { expect(subject.cover.persisted?).to be_truthy }
-        it { expect(subject.cover).to eq image }
+      it do
+        expect(subject).to be_persisted
+        expect(subject.cover).to be_persisted
+        expect(subject.cover).to eq(image)
       end
     end
 


### PR DESCRIPTION
https://jira.railsc.ru/browse/CK-99

Ошибка происходила из-за проверки `new_record?` в динамическом методе
`#{name}_attributes=(attributes)`. Его я удалил. Ещё я удалил `alias_method_chain :cover, :build`, т.к. он только вносит путаницу. В apress-deals используется cover_without_build, надо будет заменить просто на cover.
