### PR TITLE
feature: images#destroy action

### DIFF
--- a/app/controllers/apress/images/images_controller.rb
+++ b/app/controllers/apress/images/images_controller.rb
@@ -37,6 +37,17 @@ module Apress
         render json: {ids: ids}
       end
 
+      # Public: destroy an image. Expects to receive :id in params.
+      #
+      # Returns http headers with the status code.
+      def destroy
+        if model.destroy_all(id: params.require(:id)).present?
+          head :no_content
+        else
+          head :unprocessable_entity
+        end
+      end
+
       protected
 
       def uploader

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
   scope constraints: {domain: :current}, module: 'apress/images' do
     post 'images' => 'images#upload', as: :images_upload
     get 'images/previews' => 'images#previews', as: :preview_images
+    delete 'images' => 'images#destroy', as: :destroy_image
   end
 end

--- a/spec/app/controllers/apress/images/images_controller_spec.rb
+++ b/spec/app/controllers/apress/images/images_controller_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe Apress::Images::ImagesController, type: :controller do
       it { expect(JSON.parse(response.body)['status']).to eq 'error' }
     end
   end
+
+  describe '#destroy' do
+    context 'when success' do
+      before { xhr :delete, :destroy, model: 'SubjectImage', id: image.id }
+
+      it { expect(response).to have_http_status(:no_content) }
+    end
+
+    context 'when failure' do
+      before { xhr :delete, :destroy, model: 'SubjectImage', id: image.id + 1 }
+
+      it { expect(response).to have_http_status(:unprocessable_entity) }
+    end
+  end
 end


### PR DESCRIPTION
https://jira.railsc.ru/browse/CK-100 согласно http спеку надо возвращать 204 при удалении и наверное 422, если не получилось.

Должна быть авторизация, потому что иначе любой пользователь сможет удалить все картинки из БД. Желательно ещё проверять, что пользователь имеет права не только на удаление _в принципе_, но и на конкретное изображение.
