### PR TITLE
fix image assignment through nested attributes

### DIFF
--- a/spec/app/models/apress/images/subject_spec.rb
+++ b/spec/app/models/apress/images/subject_spec.rb
@@ -70,23 +70,119 @@ RSpec.describe Subject, type: :model do
         it { expect(subject.cover.persisted?).to be_truthy }
       end
 
-      context 'when update with new cover' do
-        let(:subject) { create :subject_with_cover }
-        let(:new_image) do
-          cover = subject.cover
-          cover.img = Rack::Test::UploadedFile.new(Rails.root.join('../fixtures/images/sample_image.jpg'), 'image/jpeg')
-          cover.save
-          cover
-        end
+      context 'when replacing the cover' do
+        let!(:subject) { create :subject_with_cover }
+        let!(:old_cover) { subject.cover }
+        let!(:new_cover) { create :subject_image }
 
         before do
-          subject.assign_attributes(cover_attributes: {'id' => new_image.id})
+          subject.cover_attributes = {'id' => new_cover.id}
+        end
+
+        it do
+          expect(subject.cover).to eq(new_cover)
+          expect(old_cover.subject_id).to eq(nil)
+        end
+      end
+
+      context 'when updating the cover' do
+        let(:subject) { create :subject_with_cover }
+
+        before do
+          subject.cover_attributes = {'id' => subject.cover.id, 'comment' => 'Tap'}
+        end
+
+        it { expect(subject.cover.comment).to eq('Tap') }
+      end
+
+      context "when simultaneously replacing the cover and updating some of it's attributes" do
+        let(:subject) { create :subject_with_cover }
+        let(:new_cover) { create :subject_image }
+
+        before do
+          subject.cover_attributes = {'id' => new_cover.id, 'comment' => 'Tap'}
+        end
+
+        it do
+          expect(subject.cover).to eq(new_cover)
+          expect(subject.cover.comment).to eq('Tap')
+        end
+      end
+
+      context "when simultaneously replacing the cover and updating some of it's attributes with invalid values" do
+        let!(:subject) { create :subject_with_cover }
+        let!(:old_cover) { subject.cover }
+        let!(:new_cover) { create :subject_image }
+
+        before do
+          subject.cover_attributes = {'id' => new_cover.id, 'img_content_type' => 1337}
+        end
+
+        it do
+          expect(subject).to be_invalid
+          expect(subject.errors).to include(:'cover.img_content_type')
+          expect(subject.cover).to eq(new_cover)
+          expect(old_cover.subject_id).to eq(nil)
+        end
+      end
+
+      context 'when updating the cover with id of another cover that belongs to some other subject' do
+        let!(:subject) { create :subject_with_cover }
+        let!(:subject_cover) { subject.cover }
+        let!(:other_subject) { create :subject_with_cover }
+        let!(:other_subject_cover) { other_subject.cover }
+
+        before do
+          subject.cover_attributes = {'id' => other_subject_cover.id, 'comment' => 'Tap'}
+        end
+
+        it 'does not do anything' do
+          expect(subject.cover).to eq(subject_cover)
+          expect(other_subject.cover).to eq(other_subject_cover)
+          expect(subject.cover.comment).to eq(nil)
+        end
+      end
+
+      context 'when destroying the cover through the _destroy flag' do
+        let(:subject) { create :subject_with_cover }
+
+        before do
+          subject.cover_attributes = {'id' => subject.cover.id, '_destroy' => '1'}
+        end
+
+        it { expect(subject.cover).to be_marked_for_destruction }
+      end
+
+      context 'when updating the cover without specifying id' do
+        let(:subject) { create :subject_with_cover }
+
+        before do
+          subject.cover_attributes = {'comment' => 'Tap'}
           subject.save
         end
 
-        it { expect(subject.persisted?).to be_truthy }
-        it { expect(subject.cover.persisted?).to be_truthy }
-        it { expect(subject.cover).to eq new_image }
+        it { expect(subject.cover.comment).to eq(nil) }
+      end
+
+      context 'when updating the cover by specifying nonexistent id' do
+        let(:subject) { create :subject_with_cover }
+        let(:nonexistent_id) { SubjectImage.last.id + 1 }
+
+        it do
+          expect do
+            subject.cover_attributes = {'id' => nonexistent_id, 'comment' => 'Tap'}
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when updating the cover with symbol keyed hash' do
+        let(:subject) { create :subject_with_cover }
+
+        before do
+          subject.cover_attributes = {id: subject.cover.id, comment: 'Tap'}
+        end
+
+        it { expect(subject.cover.comment).to eq('Tap') }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,6 @@ RSpec.configure do |config|
   config.include ActionDispatch::TestProcess
   config.include RSpecHtmlMatchers
   config.use_transactional_fixtures = true
+  config.filter_run_including focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
Это для https://jira.railsc.ru/browse/CK-49. В ПР https://github.com/abak-press/apress-companies-templates/pull/70 не всегда сохраняются и удаляются иконки.

Не сохраняются, потому что у загруженных иконок subject_id = nil, а [перепривязка](https://github.com/abak-press/apress-images/blob/master/app/models/concerns/apress/images/acts_as_subjectable.rb#L68) не происходит, из-за того, что компания не new_record?. Это можно починить, если в форме загрузки сразу отправлять subject_id компании, так как привязка происходит во время [загрузки](https://github.com/abak-press/apress-images/blob/master/app/services/apress/images/upload_service.rb#L47), но как выяснилось с этим проблемы и лучше починить так.

Не загружаются, потому что при нажатии кнопки "Удалить" выставляется параметр
`'_destroy' => '1'`, но, если форму не сохранить (если сохранить, то удалится), а сразу же загрузить новую иконку, то старые параметры будут заменены новыми. Потому что has_one. В apress-companies-pages работает, потому что has_many, так что там посылается массив хэшей с атрибутами, а тут просто хэш.

Изначально была идея создать экшен на удаление https://github.com/abak-press/apress-images/pull/25, но экшена не будет. Сейчас, конкретно в этом случае (с has_one), вместо удаления старой картинки, происходит отвязка, прямо во время `self.#{name} = new_image.`.

@isqad88 @Napolskih @folklore 
