### PR TITLE
fix: reset processing flag before destroy image

### DIFF
--- a/app/models/apress/images/extensions/background_processing.rb
+++ b/app/models/apress/images/extensions/background_processing.rb
@@ -7,6 +7,11 @@ module Apress
       module BackgroundProcessing
         extend ActiveSupport::Concern
 
+        included do
+          # Public: callback должен быть "навешан" раньше callback'ов paperclip-attachment'а
+          before_destroy :reset_processing_flag, if: :processing?
+        end
+
         module ClassMethods
           # Public: конфигурирует модель изображения для обработки в фоне
           #
@@ -45,6 +50,13 @@ module Apress
           update_column(:processing, true)
 
           Apress::Images::ProcessJob.enqueue(id, self.class.name)
+        end
+
+        private
+
+        def reset_processing_flag
+          self.processing = false
+          nil
         end
       end
     end

--- a/app/models/concerns/apress/images/imageable.rb
+++ b/app/models/concerns/apress/images/imageable.rb
@@ -60,17 +60,17 @@ module Apress
           define_singleton_method(:watermark_big) { options.fetch :watermark_big, WATERMARK_BIG }
           define_singleton_method(:allowed_file_names) { options.fetch :allowed_file_names, ALLOWED_FILE_NAMES }
 
+          background_processing = options.fetch(:background_processing, true)
+
+          include(Apress::Images::Extensions::BackgroundProcessing) if background_processing
+
           include Apress::Images::Extensions::Image
 
           if options.fetch(:position_normalizing, true) && column_names.include?(COLUMN_POSITION_NAME)
             include Apress::Images::PositionNormalizable
           end
 
-          return unless options.fetch(:background_processing, true)
-
-          include(Apress::Images::Extensions::BackgroundProcessing)
-
-          process_in_background options.slice(:processing_image_url, :queue_name)
+          process_in_background(options.slice(:processing_image_url, :queue_name)) if background_processing
         end
 
         # Public: Опции по-умолчанию

--- a/spec/app/models/apress/images/extensions/background_processing_spec.rb
+++ b/spec/app/models/apress/images/extensions/background_processing_spec.rb
@@ -28,4 +28,34 @@ RSpec.describe Apress::Images::Extensions::BackgroundProcessing do
       after { image.save }
     end
   end
+
+  describe 'stub urls when image in processing' do
+    let(:image) { create :delayed_image }
+    let(:image_stub) { Rails.root.join('public/foo.jpg') }
+
+    before do
+      FileUtils.cp(
+        Rails.root.join('public/images/stub_thumb.gif'),
+        image_stub
+      )
+
+      DelayedImage.attachment_definitions[:img][:delayed][:processing_image_url] = 'foo.jpg'
+    end
+
+    after { FileUtils.rm(image_stub) }
+
+    context 'when image destroy' do
+      before { image.destroy }
+
+      it { expect(image).to be_destroyed }
+
+      it 'reset procecesing flag' do
+        expect(image).not_to be_processing
+      end
+
+      it 'keep stub image' do
+        expect(File.exist?(image_stub)).to be
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-6698

Выяснили неприятность: если картинка находится еще в обработке, то при попытке удаления будет удалена заглушка :cry: 

[Здесь](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment.rb#L24) формируется путь к файлу. Этот путь используется во время [удаления](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment.rb#L559). В нашем случае :url изображения [ведет](https://github.com/abak-press/apress-images/blob/paperclip-upgrade/lib/apress/images/url_generator.rb#L28) на заглушку, если картинка находится в обработке (processing = true). Поэтому при удалении необходимо, чтобы флаг обработки сбрасывался в false при удалении.
