### PR TITLE
fix: возращаем для Attachemnt#most_existing_style самый крупный

### DIFF
--- a/app/models/apress/images/extensions/image.rb
+++ b/app/models/apress/images/extensions/image.rb
@@ -30,6 +30,7 @@ module Apress
                    :files,
                    :thumbs,
                    :most_existing_style,
+                   :best_style_for_copy,
                    :to_file,
                    to: :img,
                    allow_nil: true

--- a/lib/apress/images/extensions/attachment.rb
+++ b/lib/apress/images/extensions/attachment.rb
@@ -135,11 +135,31 @@ module Apress
           end
         end
 
-        # Public: из всех стилей первый, файл которого существует
+        # Public: из всех стилей первый самый большой(по площади), файл которого существует
         #
         # Returns Symbol
         def most_existing_style
-          thumbs.find { |t| exists?(t) }
+          thumbs
+            .map do |style_name|
+              geo = Paperclip::Geometry.parse(styles[style_name].geometry)
+              area = geo.width * geo.height
+              sort_value = -area # самые большие, при сортировке, встанут первыми
+              [style_name, sort_value]
+            end
+            .sort_by(&:last)
+            .find { |(style_name, _area)| exists?(style_name) }
+            .first
+        end
+
+        # Public: выбирает стиль, наиболее подходящий для копирования
+        #
+        # Returns Symbol
+        def best_style_for_copy
+          if exists?(:original)
+            :original
+          else
+            most_existing_style
+          end
         end
 
         # Public: файл для стиля

--- a/spec/app/models/apress/images/subject_image_spec.rb
+++ b/spec/app/models/apress/images/subject_image_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe SubjectImage, type: :model do
       expect(image.files).to eq(image.img.files)
       expect(image.fingerprints).to eq(image.img.fingerprints)
       expect(image.most_existing_style).to eq(image.img.most_existing_style)
+      expect(image.best_style_for_copy).to eq(image.img.best_style_for_copy)
     end
   end
 

--- a/spec/internal/app/models/subject_image.rb
+++ b/spec/internal/app/models/subject_image.rb
@@ -1,5 +1,19 @@
 class SubjectImage < ActiveRecord::Base
   include Apress::Images::Imageable
 
-  acts_as_image(background_processing: false)
+  acts_as_image(
+    attachment_options: {
+      styles: {
+        big: {
+          geometry: '600x600>',
+          animated: false
+        },
+        small: {
+          geometry: '50x50>',
+          animated: false
+        }
+      }
+    },
+    background_processing: false
+  )
 end

--- a/spec/lib/apress/images/extensions/attachment_spec.rb
+++ b/spec/lib/apress/images/extensions/attachment_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Paperclip::Attachment do
         File.unlink(image.img.path(:original))
       end
 
-      it 'restores original from must existing style' do
+      it 'restores original from most existing style' do
         expect(image.img).not_to be_exists(:original)
         image.img.process_delayed!
         expect(image.img).to be_exists(:original)
@@ -75,13 +75,40 @@ RSpec.describe Paperclip::Attachment do
   end
 
   describe '#most_existing_style' do
-    before { allow_any_instance_of(described_class).to receive(:path).and_return(dummy_filepath) }
+    let(:image) { create :subject_image }
 
-    it { expect(image.img.most_existing_style).to eq(:thumb) }
+    it { expect(image.img.most_existing_style).to eq(:big) }
+  end
+
+  describe '#best_style_for_copy' do
+    let(:image) { create :subject_image }
+
+    context 'original exists' do
+      it { expect(image.img.best_style_for_copy).to eq(:original) }
+    end
+
+    context 'original missing' do
+      before do
+        File.unlink(image.img.path(:original))
+      end
+
+      it { expect(image.img.best_style_for_copy).to eq(:big) }
+    end
+
+    context 'original and big version missing' do
+      before do
+        File.unlink(image.img.path(:original))
+        File.unlink(image.img.path(:big))
+      end
+
+      it { expect(image.img.best_style_for_copy).to eq(:thumb) }
+    end
   end
 
   describe '#thumbs' do
-    it { expect(image.img.thumbs).to match_array([:thumb]) }
+    let(:image) { create :subject_image }
+
+    it { expect(image.img.thumbs).to match_array([:big, :thumb, :small]) }
   end
 
   describe '#files' do


### PR DESCRIPTION
подготовка к https://jira.railsc.ru/browse/SERVICES-1126
обнаружил, что при мердже опция аттачмента https://github.com/abak-press/apress-images/blob/master/app/models/concerns/apress/images/imageable.rb#L55
thumb всегда идет после оригинала
