### PR TITLE
fix: не прогонять миграцию с pgvector в других гемах and Release 7.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    apress-images (7.8.5)
+    apress-images (7.9.1)
       addressable (>= 2.3.2)
       apress-api (>= 1.8.0)
       class_logger (~> 1.0.1)
@@ -209,7 +209,7 @@ GEM
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
     resque-failed-job-mailer (0.0.3)
-    resque-integration (3.8.2)
+    resque-integration (3.9.0)
       god (~> 0.13.4)
       multi_json
       rails (>= 3.0.0)

--- a/db/migrate/20260204152101_create_product_image_hashes.rb
+++ b/db/migrate/20260204152101_create_product_image_hashes.rb
@@ -3,6 +3,7 @@
 class CreateProductImageHashes < ActiveRecord::Migration
   def up
     return if Rails.env.staging?
+    return if conn_name.nil?
 
     conn.enable_extension 'vector'
 
@@ -19,13 +20,18 @@ class CreateProductImageHashes < ActiveRecord::Migration
 
   def down
     return if Rails.env.staging?
+    return if conn_name.nil?
 
     conn.drop_table :product_image_hashes
   end
 
   private
 
+  def conn_name
+    Rails.application.config.images.fetch(:image_hashes_storage_connection)
+  end
+
   def conn
-    ActiveRecord::Base.on(Rails.application.config.images.fetch(:image_hashes_storage_connection)).connection
+    ActiveRecord::Base.on(conn_name).connection
   end
 end

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    apress-images (7.8.5)
+    apress-images (7.9.1)
       addressable (>= 2.3.2)
       apress-api (>= 1.8.0)
       class_logger (~> 1.0.1)
@@ -209,7 +209,7 @@ GEM
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
     resque-failed-job-mailer (0.0.3)
-    resque-integration (3.8.2)
+    resque-integration (3.9.0)
       god (~> 0.13.4)
       multi_json
       rails (>= 3.0.0)

--- a/lib/apress/images/engine.rb
+++ b/lib/apress/images/engine.rb
@@ -40,7 +40,7 @@ module Apress
             MIME::Types['image/png']
           ).to_set,
           not_resized_types: [%r{^image/svg}],
-          image_hashes_storage_connection: 'image_hashes_storage',
+          image_hashes_storage_connection: nil, # Задать в проекте, например в ПЦ 'image_hashes_storage'
           hashing_logger: Logger.new(Rails.root.join('log', 'images_hashing.log')).tap do |l|
             l.formatter = Logger::Formatter.new
           end

--- a/lib/apress/images/version.rb
+++ b/lib/apress/images/version.rb
@@ -1,5 +1,5 @@
 module Apress
   module Images
-    VERSION = '7.9.0'.freeze
+    VERSION = '7.9.1'.freeze
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ Redis.current = Redis.new(host: ENV['TEST_REDIS_HOST'])
 Resque.redis = Redis.current
 
 RSpec.configure do |config|
+  Rails.application.config.images[:image_hashes_storage_connection] = 'image_hashes_storage'
+
   config.include FactoryGirl::Syntax::Methods
   config.include Paperclip::Shoulda::Matchers
   config.include ActionDispatch::TestProcess


### PR DESCRIPTION
Чтобы не тащить образ с pgvector во все зависимые гемы

При подключении задать в инишиалайзере название коннекции, например
`Rails.application.config.images[:image_hashes_storage_connection] = 'image_hashes_storage'`